### PR TITLE
[bugfix] missing import for CoAP in packet registry

### DIFF
--- a/microschc/protocol/__init__.py
+++ b/microschc/protocol/__init__.py
@@ -7,6 +7,7 @@ from .ipv4 import IPv4ComputeFunctions, IPv4Fields
 from .ipv6 import IPv6ComputeFunctions, IPv6Fields
 from .udp import UDPComputeFunctions, UDPFields
 from .sctp import SCTPComputeFunctions, SCTPFields
+from .coap import CoAPFields
 
 ComputeFunctions: Dict[str, Tuple[ComputeFunctionType, ComputeFunctionDependenciesType]] = {
     IPv4Fields.TOTAL_LENGTH: IPv4ComputeFunctions[IPv4Fields.TOTAL_LENGTH],

--- a/tests/protocol/test_registry.py
+++ b/tests/protocol/test_registry.py
@@ -1,0 +1,11 @@
+from microschc.protocol.registry import Stack, factory
+from microschc.parser import PacketParser
+from microschc.rfc8724 import PacketDescriptor
+
+
+def test_stack_ipv6_udp_coap():
+    """
+    test the IPv6/UDP/CoAP stack parser import
+    """
+    packet_parser: PacketParser = factory(stack_id=Stack.IPV6_UDP_COAP)
+    assert len(packet_parser.parsers) == 3


### PR DESCRIPTION
Thanks @PhS38240 for the bug identification !