### PR TITLE
fix(compressor): Filter rule field descriptors by matching direction

### DIFF
--- a/microschc/compressor/compressor.py
+++ b/microschc/compressor/compressor.py
@@ -4,17 +4,18 @@ Implementation SCHC packet compression as described in section 7.2 of [1].
 [1] "SCHC: Generic Framework for Static Context Header Compression and Fragmentation" , A. Minaburo et al.
 '''
 
-from typing import List, Tuple
+from typing import List
 from microschc.actions.compression import least_significant_bits, mapping_sent, value_sent
 from microschc.binary.buffer import Buffer, Padding
-from microschc.rfc8724 import FieldDescriptor, MatchMapping, PacketDescriptor, RuleDescriptor, RuleNature
+from microschc.rfc8724 import FieldDescriptor, MatchMapping, PacketDescriptor, RuleDescriptor, RuleFieldDescriptor, RuleNature
 from microschc.rfc8724 import CompressionDecompressionAction as CDA
+from microschc.rfc8724 import DirectionIndicator as DI
 
 
 def compress(packet_descriptor: PacketDescriptor, rule_descriptor: RuleDescriptor) -> Buffer:
     """
-        Compress the packet fields following the rule's compression actions.
-        See section 7.2 of [1].
+    Compress the packet fields following the rule's compression actions.
+    See section 7.2 of [1].
     """
     schc_packet: Buffer = Buffer(content=b'', length=0, padding=Padding.RIGHT)
 
@@ -25,8 +26,13 @@ def compress(packet_descriptor: PacketDescriptor, rule_descriptor: RuleDescripto
     packet_fields: List[FieldDescriptor] = packet_descriptor.fields
 
     if rule_descriptor.nature is RuleNature.COMPRESSION:
+        # Filter rule fields by direction
+        matching_fields: List[RuleFieldDescriptor] = [
+            rf for rf in rule_descriptor.field_descriptors
+            if rf.direction == packet_descriptor.direction or rf.direction == DI.BIDIRECTIONAL
+        ]
 
-        for pf, rf in zip(packet_fields, rule_descriptor.field_descriptors):
+        for pf, rf in zip(packet_fields, matching_fields):
             field_residue: Buffer
             if rf.compression_decompression_action in {CDA.NOT_SENT, CDA.COMPUTE}:
                 continue

--- a/tests/decompressor/test_decompressor.py
+++ b/tests/decompressor/test_decompressor.py
@@ -143,6 +143,7 @@ def test_decompression_compute():
 
     packet_parser: PacketParser = factory(stack_id=Stack.IPV6_UDP_COAP)
     packet_descriptor: PacketDescriptor = packet_parser.parse(buffer=packet_buffer)
+    packet_descriptor.direction = DirectionIndicator.UP
     packet_fields: List[FieldDescriptor] = packet_descriptor.fields
 
     field_descriptors_1: List[RuleFieldDescriptor] = [


### PR DESCRIPTION
1. Filter rule field descriptors to only match fields where:
   - Field direction matches packet direction
   - Or field direction is bidirectional
2. Prevents mismatched compression when rule fields don't align with packet direction
3. Update test_decompressor.py by setting the right PacketDescriptor.direction before compression

This error was introducing shifted compararison over packet field descriptor and rule field descriptor.