### PR TITLE
feature(Ruler): Update exception handling for Ruler::match_packet_descriptor

### DIFF
--- a/microschc/ruler/ruler.py
+++ b/microschc/ruler/ruler.py
@@ -33,6 +33,8 @@ class Ruler:
         packet_fields: List[FieldDescriptor] = packet_descriptor.fields
         packet_direction: DirectionIndicator = packet_descriptor.direction
 
+        rule_match: bool = False
+
         for rule in self.rules:
             
             if rule.nature is RuleNature.COMPRESSION:
@@ -48,10 +50,15 @@ class Ruler:
                     continue
 
                 # rule matches, return it
+                rule_match = True
                 yield rule
 
             elif rule.nature is RuleNature.NO_COMPRESSION:
+                rule_match = True
                 yield rule
+        
+        if not rule_match:
+            raise RuleDescriptorMatchError(packet_descriptor=packet_descriptor)
         
     
     def match_schc_packet(self, schc_packet: Buffer) -> RuleDescriptor:


### PR DESCRIPTION
Update Ruler::match_packet_descriptor which now raises a RuleDescriptorMatchError (already defined) exception if no rules, even no-compression, could be associated with a PacketDescriptor.