### PR TITLE
fix(compressor): Fix no-compression case during compression processing

### DIFF
--- a/microschc/compressor/compressor.py
+++ b/microschc/compressor/compressor.py
@@ -48,10 +48,7 @@ def compress(packet_descriptor: PacketDescriptor, rule_descriptor: RuleDescripto
         schc_packet += packet_descriptor.payload
 
     elif rule_descriptor.nature is RuleNature.NO_COMPRESSION:
-        for pf in packet_fields:
-            schc_packet += value_sent(field_descriptor=pf)
-
-        schc_packet += packet_descriptor.payload
+        schc_packet += packet_descriptor.raw
 
     return schc_packet
 


### PR DESCRIPTION
# Fix SCHC Compressor

## Issue Description
The previous version of the compress function, for the no-compression case, was working with the syntactic case. Indeed, the issue with the last code was the omission of the CoAP option's real value for semantic implementation.

## Solution
In both cases, semantic or syntactic, SCHC compression thanks to the no-compression rule is literally getting the Rule ID value and concatenating the packet. Therefore, it is not required to review all the RuleFieldDescriptors in a row.